### PR TITLE
Corrected ring_road symbol for FR

### DIFF
--- a/code/signs_FR.pl
+++ b/code/signs_FR.pl
@@ -136,7 +136,7 @@
  recycling_centre => "../../destinations/code/symbols/FR_ID24.svg", 
  rest_area        => "../../destinations/code/symbols/parking.svg",   
  restaurant       => "../../destinations/code/symbols/restaurant.svg", 
- ring_road        => "../../destinations/code/symbols/FR_SU5.svg",   
+ ring_road        => "../../destinations/code/symbols/FR_SU4.svg",   
  's-bahn'         => "../../destinations/code/symbols/sbahn.svg", 
  shopping_centre  => "../../destinations/code/symbols/FR_ID36.svg", 
  slipway          => "../../destinations/code/symbols/FR_ID20e.svg", 


### PR DESCRIPTION
This PR corrects the bug/typo signaled [here](https://github.com/mueschel/OsmDestinationToSVG/pull/19#issuecomment-3244542067).